### PR TITLE
Close out chromedriver instances when done

### DIFF
--- a/GoogleScraper/selenium_mode.py
+++ b/GoogleScraper/selenium_mode.py
@@ -589,7 +589,7 @@ class SelScrape(SearchEngineScrape, threading.Thread):
             self.search()
 
         if self.webdriver:
-            self.webdriver.close()
+            self.webdriver.quit()
 
 
 """


### PR DESCRIPTION
webdriver.quit() works better than .close(); at least on Windows 8; the latter leaves chromedriver instances open when running scrape_with_config