### PR TITLE
Fix GoogleParser first-child selector problem.

### DIFF
--- a/GoogleScraper/parsing.py
+++ b/GoogleScraper/parsing.py
@@ -354,17 +354,17 @@ class GoogleParser(Parser):
             'us_ip': {
                 'container': '#center_col',
                 'result_container': 'div.g ',
-                'link': 'h3.r > a:first-child::attr(href)',
+                'link': 'h3.r > a::attr(href)',
                 'snippet': 'div.s span.st::text',
-                'title': 'h3.r > a:first-child::text',
+                'title': 'h3.r > a::text',
                 'visible_link': 'cite::text'
             },
             'de_ip': {
                 'container': '#center_col',
                 'result_container': 'li.g ',
-                'link': 'h3.r > a:first-child::attr(href)',
+                'link': 'h3.r > a::attr(href)',
                 'snippet': 'div.s span.st::text',
-                'title': 'h3.r > a:first-child::text',
+                'title': 'h3.r > a::text',
                 'visible_link': 'cite::text'
             },
             'de_ip_news_items': {
@@ -379,17 +379,17 @@ class GoogleParser(Parser):
             'us_ip': {
                 'container': '#center_col',
                 'result_container': 'li.ads-ad',
-                'link': 'h3.r > a:first-child::attr(href)',
+                'link': 'h3.r > a::attr(href)',
                 'snippet': 'div.s span.st::text',
-                'title': 'h3.r > a:first-child::text',
+                'title': 'h3.r > a::text',
                 'visible_link': '.ads-visurl cite::text',
             },
             'de_ip': {
                 'container': '#center_col',
                 'result_container': '.ads-ad',
-                'link': 'h3 > a:first-child::attr(href)',
+                'link': 'h3 > a::attr(href)',
                 'snippet': '.ads-creative::text',
-                'title': 'h3 > a:first-child::text',
+                'title': 'h3 > a::text',
                 'visible_link': '.ads-visurl cite::text',
             }
         },


### PR DESCRIPTION
For now, the GoogleParser can't parse results of files like these:

[PDF]david singer (LoA).pdf
home.sogang.ac.kr/.../david%20singer%20(LoA).pd...

In this case, since <span class="_ogd b w xsm">[PDF]</span> is the first child and <a href="..."> is the second child, the parser can't parse the link. However, w/o first-child works very well in both cases(file and non-file cases). I think this is somewhat redundant and should be removed.