### PR TITLE
Fixed invalid folder name during installation on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(name='GoogleScraper',
       py_modules=['usage'],
       packages=['GoogleScraper'],
       entry_points={'console_scripts': ['GoogleScraper = GoogleScraper.core:main']},
-      package_dir={'examples': 'examples/'},
+      package_dir={'examples': 'examples'},
       install_requires=requirements
 )


### PR DESCRIPTION
Currently the installation of the package fails on windows OS because of an invalid folder name. The commit fixes this issue.  
Original error message:  
`File "c:\python34\lib\distutils\util.py", line 127, in convert_path`  
`raise ValueError("path '%s' cannot end with '/'" % pathname)`  
`ValueError: path 'examples/' cannot end with '/'`