### PR TITLE
L 24, changed 'examples/' to 'examples'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(name='GoogleScraper',
       py_modules=['usage'],
       packages=['GoogleScraper'],
       entry_points={'console_scripts': ['GoogleScraper = GoogleScraper.core:main']},
-      package_dir={'examples': 'examples/'},
+      package_dir={'examples': 'examples'},
       install_requires=requirements
 )


### PR DESCRIPTION
Reason: made the windows pip install crash.